### PR TITLE
Docs, Dockerfile updates, add'l test cases added

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,25 @@ This single tar.gz file can be copied from that host (for example via SCP) and l
 * You can customize the initial setup of the master by modifying jenkins/loadtestsetup.groovy, for example to modify security setup or add users.  Note that **you must make the Groovy commands idempotent, because this will run every time you start the Docker image baked from it.**
 * To grab a heap dump (note that you must have the java debug symbols installed, i.e. package openjdk-8-dbg/stable): 
     - `docker exec -it -u jenkins jenkins bash`
-    - `jmap -dump:live,format=b,file=/tmp/heapdump.bin 9`
+
+        You'll be running a shell inside of the Jenkins docker container under test. Now, run:
+
+        ```
+        jenkins@jenkins:/$ ps -ef
+        UID        PID  PPID  C STIME TTY          TIME CMD
+        jenkins      1     0  0 18:55 pts/0    00:00:00 /sbin/tini -- /usr/local/bin/full-start.sh
+        jenkins      9     1  0 18:55 pts/0    00:00:00 /bin/bash /usr/local/bin/full-start.sh
+        jenkins     10     9  1 18:55 pts/0    00:02:22 telegraf
+        jenkins     11     9 79 18:55 pts/0    01:50:25 java -Duser.home=/var/jenkins_home -Dgraphite.metrics.intervalSeconds=10 -Dcom.sun.management.jmxremote -Dcom.sun.manag
+        ```
+        In our example, Jenkins is running under PID 11. Meaning we can now run:
+
+    - `jmap -dump:live,format=b,file=/tmp/heapdump.bin 11`
+    
+        Which will save the file to disk. Now, exit the docker container with `exit`, and from your host machine, run:
+
     - `docker cp jenkins:/tmp/heapdump.bin ./heapdump.bin`
-* 
- `jmap -dump:live,file=/tmp/heapdump.hprof 9` (where 9 is the process ID)
+* From here, you can use your favorite heap analysis tool, like maybe visualvm, to look at what's going on.
 
 ## Git Server: testcases, shared libraries and testcase data
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ ssh-agent $(ssh-add ./id_rsa; git push origin $myBranchName)
 * Suggested starting point: [Core metrics dashdoard](http://localhost:81/dashboard/db/scalability-lab-core-metrics)
 * Note that you may need to change the "root block device id" variable to get IO info to show correctly (it'll be echoed when launching the environment)
     - For example if the root device for Jenkins is /dev/vda (Mac with "native" Docker, generally), this will be "vda"
-    - You can obtain it by running the following: `echo $(docker run --rm -it tutum/influxdb lsblk -d -o NAME | tail -n 1 | tr -d '\r' | tr -d '\n')`
+    - You can obtain it by running the following: `echo $(docker run --rm -it jenkins/jenkins lsblk -d -o NAME | tail -n 1 | tr -d '\r' | tr -d '\n')`
     - If your Jenkins container has resource limits, the device name will be there
     - Grafana will also bind in the environment variable "$ROOT_BLKDEV_NAME", so if the environment is fully running you can do `docker exec grafana bash -c 'echo $ROOT_BLKDEV_NAME'`
 

--- a/gitserver/testcases/ClassloadingTakeOne/Jenkinsfile
+++ b/gitserver/testcases/ClassloadingTakeOne/Jenkinsfile
@@ -1,8 +1,3 @@
-/*
-Devin's incredibly clever way to do this testing follows below. This 
-is lifted in its entirety from a ticket.
-*/
-
 // Property accesses like `map.A` cause Groovy to try to load `map$A` and `map.A` as classes.
 def map = ['A': ['B': ['C': ['D': ['E': ['F': true]]]]]]
 def a = map.A
@@ -27,10 +22,10 @@ def fC = c.D.E.F
 def fD = d.E.F
 def fE = e.F
 
-// Clears out the cache before PR 265, could happen if Jenkins was under heavy load
+// Clears out the cache before PR script-security 1.66. Possible if Jenkins is 
+// under heavy load. 
 System.gc()
 
-// Load all of the same classes again
 map = ['A': ['B': ['C': ['D': ['E': ['F': true]]]]]]
 a = map.A
 b = map.A.B
@@ -57,4 +52,3 @@ abc = map.A.B.C
 abcd = map.A.B.D
 abcde = map.A.B.C.D.E
 abcdef = map.A.B.C.D.E.F
-

--- a/gitserver/testcases/ClassloadingTakeOne/Jenkinsfile
+++ b/gitserver/testcases/ClassloadingTakeOne/Jenkinsfile
@@ -1,0 +1,60 @@
+/*
+Devin's incredibly clever way to do this testing follows below. This 
+is lifted in its entirety from a ticket.
+*/
+
+// Property accesses like `map.A` cause Groovy to try to load `map$A` and `map.A` as classes.
+def map = ['A': ['B': ['C': ['D': ['E': ['F': true]]]]]]
+def a = map.A
+def b = map.A.B
+def bA = a.B
+def c = map.A.B.C
+def cA = a.B.C
+def cB = b.C
+def d = map.A.B.C.D
+def dA = a.B.C.D
+def dB = b.C.D
+def dC = c.D
+def e = map.A.B.C.D.E
+def eA = a.B.C.D.E
+def eB = b.C.D.E
+def eC = c.D.E
+def eD = d.E
+def f = map.A.B.C.D.E.F
+def fA = a.B.C.D.E.F
+def fB = b.C.D.E.F
+def fC = c.D.E.F
+def fD = d.E.F
+def fE = e.F
+
+// Clears out the cache before PR 265, could happen if Jenkins was under heavy load
+System.gc()
+
+// Load all of the same classes again
+map = ['A': ['B': ['C': ['D': ['E': ['F': true]]]]]]
+a = map.A
+b = map.A.B
+bA = a.B
+c = map.A.B.C
+cA = a.B.C
+cB = b.C
+d = map.A.B.C.D
+dA = a.B.C.D
+dB = b.C.D
+dC = c.D
+e = map.A.B.C.D.E
+eA = a.B.C.D.E
+eB = b.C.D.E
+eC = c.D.E
+eD = d.E
+f = map.A.B.C.D.E.F
+fA = a.B.C.D.E.F
+fB = b.C.D.E.F
+fC = c.D.E.F
+fD = d.E.F
+fE = e.F
+abc = map.A.B.C
+abcd = map.A.B.D
+abcde = map.A.B.C.D.E
+abcdef = map.A.B.C.D.E.F
+

--- a/gitserver/testcases/ClassloadingTakeTwo/Jenkinsfile
+++ b/gitserver/testcases/ClassloadingTakeTwo/Jenkinsfile
@@ -1,0 +1,67 @@
+def r = Math.random()
+def maybeRunGC = { threshold ->
+    if (r > threshold - 0.1 && r < threshold) {
+        // Clears out the cache before PR 265, could happen if Jenkins was under heavy load
+        System.gc();
+    } else {
+        // Introduce some variability
+        Thread.sleep(100);
+    }
+}
+
+def map = ['A': ['B': ['C': ['D': ['E': ['F': true]]]]]]
+def a = map.A
+maybeRunGC(0.1)
+def b = map.A.B
+def bA = a.B
+maybeRunGC(0.2)
+def c = map.A.B.C
+def cA = a.B.C
+def cB = b.C
+maybeRunGC(0.3)
+def d = map.A.B.C.D
+def dA = a.B.C.D
+def dB = b.C.D
+def dC = c.D
+maybeRunGC(0.4)
+def e = map.A.B.C.D.E
+def eA = a.B.C.D.E
+def eB = b.C.D.E
+def eC = c.D.E
+def eD = d.E
+maybeRunGC(0.5)
+def f = map.A.B.C.D.E.F
+def fA = a.B.C.D.E.F
+def fB = b.C.D.E.F
+def fC = c.D.E.F
+def fD = d.E.F
+def fE = e.F
+
+// Load all of the same classes again
+a = map.A
+maybeRunGC(0.6)
+b = map.A.B
+bA = a.B
+maybeRunGC(0.7)
+c = map.A.B.C
+cA = a.B.C
+cB = b.C
+maybeRunGC(0.8)
+d = map.A.B.C.D
+dA = a.B.C.D
+dB = b.C.D
+dC = c.D
+maybeRunGC(0.9)
+e = map.A.B.C.D.E
+eA = a.B.C.D.E
+eB = b.C.D.E
+eC = c.D.E
+eD = d.E
+maybeRunGC(1.0)
+f = map.A.B.C.D.E.F
+fA = a.B.C.D.E.F
+fB = b.C.D.E.F
+fC = c.D.E.F
+fD = d.E.F
+fE = e.F
+

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,26 +1,17 @@
-FROM jenkinsci/jenkins:2.121.3
+FROM jenkins/jenkins
 
-MAINTAINER svanoort
+MAINTAINER kshultz
 
 # Install telegraf for monitoring && set up telegraf as sudoer so they can launch telegraf as root for extra disk stats
 # Also you need openjdk-8-dbg/stable to get the debugging symbols for heap dumps
 USER root
-RUN apt-get update && apt-get install -y sudo bc openjdk-8-dbg/stable \
+RUN apt-get update && apt-get install -y openjdk-8-dbg \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /var/tmp/* \
     && echo 'telegraf ALL=(root) NOPASSWD:ALL' >> /etc/sudoers 
 RUN curl -o /tmp/telegraf.deb https://dl.influxdata.com/telegraf/releases/telegraf_1.3.5-1_amd64.deb \
     && dpkg -i /tmp/telegraf.deb && rm -f telegraf.deb
 USER jenkins
 COPY --chown=jenkins:jenkins telegraf.conf /etc/telegraf/telegraf.conf
-
-########
-# Karl WIP:
-# I'd like to not have to manually install tools `jdk8` and `mvn` from the Jenkins UI once 
-# the container is up. I'd like that to be automatic.
-# Download and install Maven
-# RUN wget --no-verbose -O /tmp/apache-maven-3.5.0-bin.tar.gz http://archive.apache.org/dist/maven/maven-3/3.5.0/binaries/apache-maven-3.5.0-bin.tar.gz
-# Verify the Maven download
-# RUN echo "35c39251d2af99b6624d40d801f6ff02 /tmp/apache-maven-3.5.0-bin.tar.gz" | md5sum -c
 
 # Make tini launch helper script that invokes telegraf as well as Jenkins
 COPY --chown=jenkins:jenkins full-start.sh /usr/local/bin/full-start.sh

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,6 +1,5 @@
+# No longer jenkinsci/jenkins.
 FROM jenkins/jenkins
-
-MAINTAINER kshultz
 
 # Install telegraf for monitoring && set up telegraf as sudoer so they can launch telegraf as root for extra disk stats
 # Also you need openjdk-8-dbg/stable to get the debugging symbols for heap dumps


### PR DESCRIPTION
# Summary

This pull request includes a handful of changes I made while helping to validate the fix for [JENKINS-59587](https://issues.jenkins-ci.org/browse/JENKINS-59587).

# Details

Included in this PR are:

* Documentation changes to the README. Mostly formatting, but one change provides a more accurate way of getting the block device Jenkins is using. 
* Two additional test cases, which target classloading performance. These were created by @dwnusbaum.
* Edits to the jenkins Dockerfile, to:
  * Remove the deprecated `MAINTANER` field
  * Switch the repository from `jenkinsci` to `jenkins`
  * Remove an old left over comment, which is no longer necessary